### PR TITLE
add a new function that approximates the polygon bounding a convex hull with a certain number of sides

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4070,6 +4070,27 @@ CV_EXPORTS_W void approxPolyDP( InputArray curve,
                                 OutputArray approxCurve,
                                 double epsilon, bool closed );
 
+/** @brief Approximates a polygon with a convex hull with a specified accuracy and number of sides.
+
+The cv::approxPolyExternal function approximates a polygon with a convex hull
+so that the difference between the contour area of the original contour and the new polygon is minimal.
+It uses a greedy algorithm for contracting two vertices into one in such a way that the additional area is minimal.
+Straight lines formed by each edge of the convex contour are drawn and the areas of the resulting triangles are considered.
+Each vertex will lie either on the original contour or outside it
+
+
+@param curve Input vector of a 2D point stored in std::vector or Mat.
+@param approxCurve Result of the approximation. The type is vector of a 2D point (Point2f or Point) in std::vector or Mat.
+@param side The parameter defines the number of sides of the result polygon.
+@param epsilon_percentage defines the percentage of the maximum of additional area.
+If it equals -1, it is not used. Otherwise algorighm stops if additional area is greater than contourArea(_curve) * percentage.
+If additional area exceeds the limit, algorithm returns as many vertices as there were at the moment the limit was exceeded.
+@param make_hull If it is true, algorithm creates a convex hull of input contour. Otherwise input vector should be convex.
+ */
+CV_EXPORTS_W void approxPolyExternal( InputArray _curve, OutputArray _approxCurve,
+                                      int side, float epsilon_percentage = -1.0,
+                                      bool make_hull = true );
+
 /** @brief Calculates a contour perimeter or a curve length.
 
 The function computes a curve length or a closed contour perimeter.

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4072,7 +4072,7 @@ CV_EXPORTS_W void approxPolyDP( InputArray curve,
 
 /** @brief Approximates a polygon with a convex hull with a specified accuracy and number of sides.
 
-The cv::approxPolyExternal function approximates a polygon with a convex hull
+The cv::approxBoundingPoly function approximates a polygon with a convex hull
 so that the difference between the contour area of the original contour and the new polygon is minimal.
 It uses a greedy algorithm for contracting two vertices into one in such a way that the additional area is minimal.
 Straight lines formed by each edge of the convex contour are drawn and the areas of the resulting triangles are considered.
@@ -4087,7 +4087,7 @@ If it equals -1, it is not used. Otherwise algorighm stops if additional area is
 If additional area exceeds the limit, algorithm returns as many vertices as there were at the moment the limit was exceeded.
 @param make_hull If it is true, algorithm creates a convex hull of input contour. Otherwise input vector should be convex.
  */
-CV_EXPORTS_W void approxPolyExternal( InputArray _curve, OutputArray _approxCurve,
+CV_EXPORTS_W void approxBoundingPoly( InputArray _curve, OutputArray _approxCurve,
                                       int side, float epsilon_percentage = -1.0,
                                       bool make_hull = true );
 

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4079,7 +4079,7 @@ Straight lines formed by each edge of the convex contour are drawn and the areas
 Each vertex will lie either on the original contour or outside it
 
 
-@param curve Input vector of a 2D point stored in std::vector or Mat.
+@param curve Input vector of a 2D points stored in std::vector or Mat, points must be float or integer.
 @param approxCurve Result of the approximation. The type is vector of a 2D point (Point2f or Point) in std::vector or Mat.
 @param side The parameter defines the number of sides of the result polygon.
 @param epsilon_percentage defines the percentage of the maximum of additional area.
@@ -4087,7 +4087,7 @@ If it equals -1, it is not used. Otherwise algorighm stops if additional area is
 If additional area exceeds the limit, algorithm returns as many vertices as there were at the moment the limit was exceeded.
 @param make_hull If it is true, algorithm creates a convex hull of input contour. Otherwise input vector should be convex.
  */
-CV_EXPORTS_W void approxBoundingPoly( InputArray _curve, OutputArray _approxCurve,
+CV_EXPORTS_W void approxBoundingPoly( InputArray curve, OutputArray approxCurve,
                                       int side, float epsilon_percentage = -1.0,
                                       bool make_hull = true );
 

--- a/modules/imgproc/src/approx.cpp
+++ b/modules/imgproc/src/approx.cpp
@@ -39,6 +39,7 @@
 //
 //M*/
 #include "precomp.hpp"
+#include <queue>
 
 /****************************************************************************************\
 *                                  Chain Approximation                                   *
@@ -858,6 +859,235 @@ cvApproxPoly( const void* array, int header_size,
     }
 
     return dst_seq;
+}
+
+
+struct neighbours
+{
+    /*
+        if relevant = -1, point has been removed
+        if relevant = 0,  the intersection in the heap must be recalculated
+        if relevant = 1,  intersection has been calculated
+    */
+    short relevant;
+    cv::Point2f point;
+    int next;
+    int prev;
+
+    neighbours(int next_ = -1, int prev_ = -1, cv::Point2f point_ = { -1, -1 })
+    {
+        next = next_;
+        prev = prev_;
+        point = point_;
+        relevant = 1;
+    }
+};
+
+struct changes
+{
+    float area;
+    int vertex;
+    cv::Point2f intersection;
+
+    changes(float area_, int vertex_, cv::Point2f intersection_)
+    {
+        area = area_;
+        vertex = vertex_;
+        intersection = intersection_;
+    }
+
+    bool operator < (const changes& elem) const
+    {
+        return (area < elem.area) || ((area == elem.area) && (vertex < elem.vertex));
+    }
+    bool operator > (const changes& elem) const
+    {
+        return (area > elem.area) || ((area == elem.area) && (vertex > elem.vertex));
+    }
+};
+
+/*
+  returns intersection point and extra area
+*/
+int recalculation(std::vector<neighbours>& hull, int vertex_id, float& area_, float& x, float& y)
+{
+    Point2f vertex = hull[vertex_id].point,
+        next_vertex = hull[hull[vertex_id].next].point,
+        extra_vertex_1 = hull[hull[vertex_id].prev].point,
+        extra_vertex_2 = hull[hull[hull[vertex_id].next].next].point;
+
+    cv::Point2f curr_edge = next_vertex - vertex,
+        prev_edge = vertex - extra_vertex_1,
+        next_edge = extra_vertex_2 - next_vertex;
+
+    float cross = prev_edge.x * next_edge.y - prev_edge.y * next_edge.x;
+    if (abs(cross) < 1e-8)
+        return -1;
+
+    float t = (curr_edge.x * next_edge.y - curr_edge.y * next_edge.x) / cross;
+    cv::Point2f intersection = vertex + cv::Point2f(prev_edge.x * t, prev_edge.y * t);
+
+    float area = 0.5f * abs((next_vertex.x - vertex.x) * (intersection.y - vertex.y) - (intersection.x - vertex.x) * (next_vertex.y - vertex.y));
+
+    area_ = area;
+    x = intersection.x;
+    y = intersection.y;
+    return 0;
+}
+
+void update(std::vector<neighbours>& hull, int vertex_id)
+{
+    neighbours& v1 = hull[vertex_id], & removed = hull[v1.next], & v2 = hull[removed.next];
+
+    removed.relevant = -1;
+    v1.relevant = 0;
+    v2.relevant = 0;
+    hull[v1.prev].relevant = 0;
+    v1.next = removed.next;
+    v2.prev = removed.prev;
+}
+
+/*
+    A greedy algorithm based on contraction of vertices for approximating a convex contour by a external polygon
+*/
+void cv::approxPolyExternal( InputArray _curve, OutputArray _approxCurve,
+                             int side, float epsilon_percentage, bool make_hull)
+{
+    CV_Assert(epsilon_percentage > 0 || epsilon_percentage == -1);
+    CV_Assert(side > 2);
+    CV_Assert(_approxCurve.type() == CV_32FC2
+        || _approxCurve.type() == CV_32SC2
+        || _approxCurve.type() == 0);
+
+    Mat curve;
+    int depth = _curve.depth();
+
+    CV_Assert(depth == CV_32F || depth == CV_32S);
+
+    if (make_hull)
+    {
+
+        cv::convexHull(_curve, curve);
+    }
+    else
+    {
+        CV_Assert(isContourConvex(_curve));
+        curve = _curve.getMat();
+    }
+
+    CV_Assert(curve.cols == 1);
+    CV_Assert(curve.rows >= side);
+
+    std::vector<neighbours> hull(curve.rows);
+    int size = curve.rows;
+    std::priority_queue<changes, std::vector<changes>, std::greater<>> areas;
+    float extra_area = 0, max_extra_area = epsilon_percentage * contourArea(_curve);
+
+    if (curve.depth() == CV_32S)
+    {
+        for (int i = 0; i < size; ++i)
+        {
+            Point t = curve.at<cv::Point>(i, 0);
+            hull[i] = neighbours(i + 1, i - 1, Point2f(t.x, t.y));
+        }
+    }
+    else
+    {
+        for (int i = 0; i < size; ++i)
+        {
+            Point2f t = curve.at<cv::Point2f>(i, 0);
+            hull[i] = neighbours(i + 1, i - 1, t);
+        }
+    }
+
+    hull[0].prev = size - 1;
+    hull[size - 1].next = 0;
+
+
+    if (size > side)
+    {
+        for (int vertex_id = 0; vertex_id < size; ++vertex_id)
+        {
+            float area, new_x, new_y;
+
+            if (recalculation(hull, vertex_id, area, new_x, new_y) == -1)
+            {
+                area = 1e+38f;
+                new_x = -1; new_y = -1;
+            }
+
+            areas.push(changes(area, vertex_id, Point2f(new_x, new_y)));
+        }
+    }
+
+    while (size > side)
+    {
+        changes base = areas.top();
+        int vertex_id = base.vertex;
+
+        if (hull[vertex_id].relevant == -1)
+        {
+            areas.pop();
+        }
+        else if (hull[vertex_id].relevant == 0)
+        {
+            float area, new_x, new_y;
+            areas.pop();
+
+            if (recalculation(hull, vertex_id, area, new_x, new_y) == -1)
+            {
+                area = 1e+38f;
+                new_x = -1; new_y = -1;
+            }
+
+            areas.push(changes(area, vertex_id, Point2f(new_x, new_y)));
+            hull[vertex_id].relevant = 1;
+        }
+        else
+        {
+            if (epsilon_percentage != -1)
+            {
+                extra_area += base.area;
+                if (extra_area > max_extra_area)
+                {
+                    break;
+                }
+            }
+
+            size--;
+            hull[vertex_id].point = base.intersection;
+            update(hull, vertex_id);
+        }
+    }
+    if (_approxCurve.type() != 0) depth = _approxCurve.depth();
+    Mat buf(1, size, CV_MAKETYPE(depth, 2));
+    int last_free = 0;
+
+    if (depth == CV_32S)
+    {
+        for (int i = 0; i < curve.rows; ++i)
+        {
+            if (hull[i].relevant != -1)
+            {
+                Point t = Point(round(hull[i].point.x), round(hull[i].point.y));
+                buf.at<Point>(0, last_free) = t;
+                last_free++;
+            }
+        }
+    }
+    else
+    {
+        for (int i = 0; i < curve.rows; ++i)
+        {
+            if (hull[i].relevant != -1)
+            {
+                buf.at<Point2f>(0, last_free) = hull[i].point;
+                last_free++;
+            }
+        }
+    }
+
+    buf.copyTo(_approxCurve);
 }
 
 /* End of file. */

--- a/modules/imgproc/src/approx.cpp
+++ b/modules/imgproc/src/approx.cpp
@@ -861,7 +861,6 @@ cvApproxPoly( const void* array, int header_size,
     return dst_seq;
 }
 
-
 struct neighbours
 {
     /*
@@ -911,7 +910,7 @@ struct changes
 */
 int recalculation(std::vector<neighbours>& hull, int vertex_id, float& area_, float& x, float& y)
 {
-    Point2f vertex = hull[vertex_id].point,
+    cv::Point2f vertex = hull[vertex_id].point,
         next_vertex = hull[hull[vertex_id].next].point,
         extra_vertex_1 = hull[hull[vertex_id].prev].point,
         extra_vertex_2 = hull[hull[hull[vertex_id].next].next].point;
@@ -948,9 +947,9 @@ void update(std::vector<neighbours>& hull, int vertex_id)
 }
 
 /*
-    A greedy algorithm based on contraction of vertices for approximating a convex contour by a external polygon
+    A greedy algorithm based on contraction of vertices for approximating a convex contour by a bounding polygon
 */
-void cv::approxPolyExternal( InputArray _curve, OutputArray _approxCurve,
+void cv::approxBoundingPoly( InputArray _curve, OutputArray _approxCurve,
                              int side, float epsilon_percentage, bool make_hull)
 {
     CV_Assert(epsilon_percentage > 0 || epsilon_percentage == -1);
@@ -999,10 +998,8 @@ void cv::approxPolyExternal( InputArray _curve, OutputArray _approxCurve,
             hull[i] = neighbours(i + 1, i - 1, t);
         }
     }
-
     hull[0].prev = size - 1;
     hull[size - 1].next = 0;
-
 
     if (size > side)
     {

--- a/modules/imgproc/test/test_approxpoly.cpp
+++ b/modules/imgproc/test/test_approxpoly.cpp
@@ -402,7 +402,7 @@ TEST(Imgproc_ApproxPoly, external)
         Mat contour1;
         cv::convexHull(contour, contour1);
         if (contour1.rows < 4) continue;
-        approxPolyExternal(contour1, corners, 4, -1, false);
+        approxBoundingPoly(contour1, corners, 4, -1, false);
         out.push_back(corners);
     };
 
@@ -414,9 +414,9 @@ TEST(Imgproc_ApproxPoly, bad_args)
     Mat img(10, 1, CV_32FC2);
     vector<vector<Point>> contours;
     vector<Point> corners;
-    ASSERT_ANY_THROW(approxPolyExternal(img, corners, 0));
-    ASSERT_ANY_THROW(approxPolyExternal(img, corners, 3, 0));
-    ASSERT_ANY_THROW(approxPolyExternal(contours, corners, 4));
+    ASSERT_ANY_THROW(approxBoundingPoly(img, corners, 0));
+    ASSERT_ANY_THROW(approxBoundingPoly(img, corners, 3, 0));
+    ASSERT_ANY_THROW(approxBoundingPoly(contours, corners, 4));
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_approxpoly.cpp
+++ b/modules/imgproc/test/test_approxpoly.cpp
@@ -377,4 +377,46 @@ TEST(Imgproc_ApproxPoly, bad_epsilon)
     ASSERT_ANY_THROW(approxPolyDP(inputPoints, outputPoints, eps, false));
 }
 
+TEST(Imgproc_ApproxPoly, external)
+{
+    string imgPath = "D:\\ITLab\\Python\\pictures\\images\\rects1.png";
+    Mat img = imread(imgPath, IMREAD_GRAYSCALE);
+    Mat thresh;
+    vector<vector<Point>> contours;
+    vector<vector<Point>> out, right_out;
+    right_out = {
+        { {132, 30}, {87, 135}, {30, 121}, {70, 30} },
+        { {262, 29}, {209, 165}, {115, 142}, {162, 29} },
+        { {420, 216}, {247, 174}, {303, 28}, {483, 26} },
+        { {140, 25}, {91, 141}, {22, 126}, {66, 25} },
+        { {270, 23}, {212, 172}, {107, 145}, {158, 23} },
+        { {492, 20}, {424, 223}, {240, 178}, {299, 22} },
+        { {475, 256}, {10, 131}, {61, 16}, {556, 0} },
+        { {559, 0}, {559, 261}, {0, 261}, {0, 0} }
+    };
+    cv::adaptiveThreshold(img, thresh, 255, CV_ADAPTIVE_THRESH_GAUSSIAN_C, CV_THRESH_BINARY, 11, 2);
+    cv::findContours(thresh, contours, 1, 1);
+    for (auto contour : contours)
+    {
+        vector<Point> corners;
+        Mat contour1;
+        cv::convexHull(contour, contour1);
+        if (contour1.rows < 4) continue;
+        approxPolyExternal(contour1, corners, 4, -1, false);
+        out.push_back(corners);
+    };
+
+    ASSERT_EQ(out, right_out);
+}
+
+TEST(Imgproc_ApproxPoly, bad_args)
+{
+    Mat img(10, 1, CV_32FC2);
+    vector<vector<Point>> contours;
+    vector<Point> corners;
+    ASSERT_ANY_THROW(approxPolyExternal(img, corners, 0));
+    ASSERT_ANY_THROW(approxPolyExternal(img, corners, 3, 0));
+    ASSERT_ANY_THROW(approxPolyExternal(contours, corners, 4));
+}
+
 }} // namespace


### PR DESCRIPTION
# Problem
I needed to reduce the number of vertices of the convex hull so that the additional area was minimal, and all vertices should be outside the contour.  

![image](https://github.com/Fest1veNapkin/opencv/assets/98156294/efac35f6-b8f0-46ec-91e4-60800432620c)

![image](https://github.com/Fest1veNapkin/opencv/assets/98156294/2292d9d7-1c10-49c9-8489-23221b4b28f7)

# Description
Initially in the contour of n vertices, at each stage we consider the intersection points of the lines formed by each adjacent edges. Each of these intersection points will form a triangle with vertices through which lines pass. Let's choose a triangle with the minimum area and merge the two vertices at the intersection point. We continue until there are more vertices than the specified number of sides of the approximated polygon
![image](https://github.com/Fest1veNapkin/opencv/assets/98156294/b87b21c4-112e-450d-a776-2a120048ca30)

# Complexity:
Using a std::priority_queue or std::set  time complexity is **(O(n\*ln(n))**, memory **O(n)**,
n - number of vertices in convex hull
![image](https://github.com/Fest1veNapkin/opencv/assets/98156294/31ad5562-a67d-4e3c-bdc2-29f8b52caf88)

## Comment
If epsilon_percentage more 0, algorithm can return more values than _side_

Algorithm returns OutputArray. If OutputArray.type() equals 0, algorithm returns values with InputArray.type()

New test uses image which are not in OpenCV_extra, needs to be added


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
